### PR TITLE
feature/posts-as-html

### DIFF
--- a/server/cmd/endpoints/info/models/info.go
+++ b/server/cmd/endpoints/info/models/info.go
@@ -4,7 +4,7 @@
 // that can be found in the LICENSE file.
 //
 
-package info
+package posts
 
 import (
 	"encoding/json"
@@ -12,78 +12,34 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-// Info is the main model of the info endpoint.
-type Info struct {
-	Picture  string `json:"picture"`
-	Greeting []Link `json:"greeting"`
-	Career   []Link `json:"career"`
-	Contact  []Link `json:"contact"`
-}
-
-// Link is a additional URL passing structure for the info.
-// If the [URL] is empty, link represents non-linkable simple text element.
-// And, if title is empty, link represents empty line.
-type Link struct {
-	// Title is the main domain of [Link] structure.
-	Title string `json:"title"`
-
-	// The reference URL provider for [Title].
-	// same approach of `<a href="http://">{Title}</a>`
-	// but in go structure model.
-	URL string `json:"url"`
-
-	// Style is a font-style identifier of [Title] field.
-	// Could be:
-	//  - bold
-	//  - italic
-	//  - strong
-	//  - p -> <p>{}</p>
-	Style string `json:"style"`
-
-	// The sub links of current link.
-	Children []Link `json:"children"`
+// Post is the main model structure of the posts endpoint.
+type Post struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Cover       string `json:"cover"`
+	Date        string `json:"date"`
+	Content     string `json:"content"`
 }
 
 // Takes byte array value of request body,
-// and translates it to valid representation of [Info] map.
-func TransformInfoBody(body []byte) map[string]interface{} {
+// and translates it to valid representation of [Post] map.
+func TransformPostBody(body []byte) map[string]interface{} {
 	var data map[string]interface{}
 	json.Unmarshal(body, &data)
 
-	var info Info
-	mapstructure.Decode(data, &info)
+	var post Post
+	mapstructure.Decode(data, &post)
 
-	return info.ToJson()
+	return post.ToJson()
 }
 
-// Takes byte array value of request body,
-// and translates it to valid representation of [Link] map.
-func TransformLinkBody(body []byte) map[string]interface{} {
-	var data map[string]interface{}
-	json.Unmarshal(body, &data)
+// ToJson converts the [Post] structure to map value.
+func (p *Post) ToJson() map[string]interface{} {
+	res, _ := json.Marshal(p)
 
-	var link Link
-	mapstructure.Decode(data, &link)
-
-	return link.ToJson()
-}
-
-// ToJson converts the [Info] structure to map value.
-func (i *Info) ToJson() map[string]interface{} {
-	b, _ := json.Marshal(&i)
-
-	var m map[string]interface{}
-	_ = json.Unmarshal(b, &m)
-
-	return m
-}
-
-// ToJson converts the [Link] structure to map value.
-func (l *Link) ToJson() map[string]interface{} {
-	b, _ := json.Marshal(&l)
-
-	var m map[string]interface{}
-	_ = json.Unmarshal(b, &m)
+	m := make(map[string]interface{})
+	json.Unmarshal(res, &m)
 
 	return m
 }

--- a/server/cmd/endpoints/info/models/info.go
+++ b/server/cmd/endpoints/info/models/info.go
@@ -4,7 +4,7 @@
 // that can be found in the LICENSE file.
 //
 
-package posts
+package info
 
 import (
 	"encoding/json"
@@ -12,34 +12,78 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-// Post is the main model structure of the posts endpoint.
-type Post struct {
-	ID          string `json:"id"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Cover       string `json:"cover"`
-	Date        string `json:"date"`
-	Content     string `json:"content"`
+// Info is the main model of the info endpoint.
+type Info struct {
+	Picture  string `json:"picture"`
+	Greeting []Link `json:"greeting"`
+	Career   []Link `json:"career"`
+	Contact  []Link `json:"contact"`
+}
+
+// Link is a additional URL passing structure for the info.
+// If the [URL] is empty, link represents non-linkable simple text element.
+// And, if title is empty, link represents empty line.
+type Link struct {
+	// Title is the main domain of [Link] structure.
+	Title string `json:"title"`
+
+	// The reference URL provider for [Title].
+	// same approach of `<a href="http://">{Title}</a>`
+	// but in go structure model.
+	URL string `json:"url"`
+
+	// Style is a font-style identifier of [Title] field.
+	// Could be:
+	//  - bold
+	//  - italic
+	//  - strong
+	//  - p -> <p>{}</p>
+	Style string `json:"style"`
+
+	// The sub links of current link.
+	Children []Link `json:"children"`
 }
 
 // Takes byte array value of request body,
-// and translates it to valid representation of [Post] map.
-func TransformPostBody(body []byte) map[string]interface{} {
+// and translates it to valid representation of [Info] map.
+func TransformInfoBody(body []byte) map[string]interface{} {
 	var data map[string]interface{}
 	json.Unmarshal(body, &data)
 
-	var post Post
-	mapstructure.Decode(data, &post)
+	var info Info
+	mapstructure.Decode(data, &info)
 
-	return post.ToJson()
+	return info.ToJson()
 }
 
-// ToJson converts the [Post] structure to map value.
-func (p *Post) ToJson() map[string]interface{} {
-	res, _ := json.Marshal(p)
+// Takes byte array value of request body,
+// and translates it to valid representation of [Link] map.
+func TransformLinkBody(body []byte) map[string]interface{} {
+	var data map[string]interface{}
+	json.Unmarshal(body, &data)
 
-	m := make(map[string]interface{})
-	json.Unmarshal(res, &m)
+	var link Link
+	mapstructure.Decode(data, &link)
+
+	return link.ToJson()
+}
+
+// ToJson converts the [Info] structure to map value.
+func (i *Info) ToJson() map[string]interface{} {
+	b, _ := json.Marshal(&i)
+
+	var m map[string]interface{}
+	_ = json.Unmarshal(b, &m)
+
+	return m
+}
+
+// ToJson converts the [Link] structure to map value.
+func (l *Link) ToJson() map[string]interface{} {
+	b, _ := json.Marshal(&l)
+
+	var m map[string]interface{}
+	_ = json.Unmarshal(b, &m)
 
 	return m
 }

--- a/server/cmd/endpoints/posts/models/post.go
+++ b/server/cmd/endpoints/posts/models/post.go
@@ -19,44 +19,7 @@ type Post struct {
 	Description string `json:"description"`
 	Cover       string `json:"cover"`
 	Date        string `json:"date"`
-	Content     []Href `json:"content"`
-}
-
-// The content token reference model.
-// Which is a dynamic structure that could represent:
-// - text(normal/linked)
-// - image
-// - code-snippet
-//
-// Each that representation should be handled by [Href]'s [Type].
-// And [Src] of [Href] is the main source of value.
-type Href struct {
-	// Type is a field that represents the rendering style of [Href].
-	//
-	// Could be:
-	//  - text
-	//  - image
-	//  - code
-	Type string `json:"typ" mapstructure:"typ"`
-
-	// Src is a field that used as source of content that has to be rendered.
-	Src string `json:"src"`
-
-	// Style is a font-style identifier of [Src] field.
-	// > In case of [Type] being any kind of text type.
-	//
-	// Could be:
-	//  - bold
-	//  - italic
-	//  - strong
-	Style string `json:"style"`
-
-	// The reference URL provider for [Src].
-	// > In case of [Type] being linked text type. <text>.
-	//
-	// same approach of `<a href="http://">{Src}</a>`
-	// but in go structure model.
-	URL string `json:"url"`
+	Content     string `json:"content"`
 }
 
 // Takes byte array value of request body,
@@ -71,31 +34,9 @@ func TransformPostBody(body []byte) map[string]interface{} {
 	return post.ToJson()
 }
 
-// Takes byte array value of request body,
-// and translates it to valid representation of [Href] map.
-func TransformHrefBody(body []byte) map[string]interface{} {
-	var data map[string]interface{}
-	json.Unmarshal(body, &data)
-
-	var href Href
-	mapstructure.Decode(data, &href)
-
-	return href.ToJson()
-}
-
 // ToJson converts the [Post] structure to map value.
 func (p *Post) ToJson() map[string]interface{} {
 	res, _ := json.Marshal(p)
-
-	m := make(map[string]interface{})
-	json.Unmarshal(res, &m)
-
-	return m
-}
-
-// ToJson converts the [Href] structure to map value.
-func (h *Href) ToJson() map[string]interface{} {
-	res, _ := json.Marshal(h)
 
 	m := make(map[string]interface{})
 	json.Unmarshal(res, &m)

--- a/server/main.go
+++ b/server/main.go
@@ -15,15 +15,13 @@ import (
 	"theiskaa.com/cmd"
 )
 
-// FIXME: runs on local server at :8080
-// TODO:  run at remote server.
 func main() {
 	router := mux.NewRouter()
 	cmd.SetUp(router)
 
 	port := os.Getenv("PORT")
 	if port == "" {
-		port = "8080"
+		port = "9090"
 		log.Printf("defaulting to port %s", port)
 	}
 

--- a/web/src/components/html_render.rs
+++ b/web/src/components/html_render.rs
@@ -1,0 +1,23 @@
+//
+// Copyright 2022-present theiskaa. All rights reserved.
+// Use of this source code is governed by Apache-2.0 license
+// that can be found in the LICENSE file.
+//
+
+use web_sys::Node;
+use yew::{prelude::*, virtual_dom::VNode};
+
+#[derive(Clone, Properties, PartialEq)]
+pub struct HtmlRenderProps {
+    pub html: String,
+}
+
+// A component to parse string html data to actual [VNode]. i.e [Html].
+#[function_component(HtmlRender)]
+pub fn html_render(HtmlRenderProps { html }: &HtmlRenderProps) -> Html {
+    let pdoc = web_sys::window().unwrap().document();
+    let pelement = pdoc.unwrap().create_element("div").unwrap();
+    pelement.set_inner_html(&html[..]);
+
+    VNode::VRef(Node::from(pelement))
+}

--- a/web/src/components/menu.rs
+++ b/web/src/components/menu.rs
@@ -5,6 +5,9 @@
 //
 
 use yew::{prelude::*, virtual_dom::VNode};
+use yew_router::prelude::*;
+
+use crate::routes::Route;
 
 #[derive(Clone, Properties, PartialEq)]
 pub struct MenuProps {
@@ -14,9 +17,12 @@ pub struct MenuProps {
 #[function_component(Menu)]
 pub fn menu(MenuProps { route }: &MenuProps) -> Html {
     let titles: Vec<(VNode, String)> = vec![
-        (html! { <a href="/">{"Info"}</a> }, String::from("/")),
         (
-            html! { <a href="/blog">{"Blog"}</a> },
+            html! { <Link<Route> to={Route::Home}> { "About" } </Link<Route>> },
+            String::from("/"),
+        ),
+        (
+            html! { <Link<Route> to={Route::Blog}> { "Blog" } </Link<Route>> },
             String::from("/blog"),
         ),
         // TODO: impl local posts page.
@@ -25,7 +31,7 @@ pub fn menu(MenuProps { route }: &MenuProps) -> Html {
             String::from(""),
         ),
         (
-            html! { <a href="/#contact">{"Contact"}</a> },
+            html! { <Link<Route> to={Route::Contact}> { "Contact" } </Link<Route>> },
             String::from("/Contact"),
         ),
     ];
@@ -43,9 +49,5 @@ pub fn menu(MenuProps { route }: &MenuProps) -> Html {
         parsed.push(html! { <div class={ class_name.clone() }> { title.0.clone() } </div> });
     }
 
-    html! {
-      <div class="menu">
-        { parsed }
-      </div>
-    }
+    html! { <div class="menu"> { parsed } </div> }
 }

--- a/web/src/components/mod.rs
+++ b/web/src/components/mod.rs
@@ -6,12 +6,14 @@
 
 mod dividers;
 mod error;
+mod html_render;
 mod loading;
 mod menu;
 mod wrapper;
 
 pub use dividers::*;
 pub use error::*;
+pub use html_render::*;
 pub use loading::*;
 pub use menu::*;
 pub use wrapper::*;

--- a/web/src/components/wrapper.rs
+++ b/web/src/components/wrapper.rs
@@ -48,10 +48,7 @@ pub fn wrapper(WrapperProps { child }: &WrapperProps) -> Html {
 pub fn footer() -> Html {
     html! {
       <footer class="footer">
-        <p>
-         { "Copyright © 2022 Ismael Shakverdiev. " }
-         <a href="" title="Privacy Policy">{ "Privacy Policy" }</a>
-        </p>
+        <p> { "Copyright © 2022 Ismael Shakverdiev" } </p>
        </footer>
     }
 }

--- a/web/src/models/mod.rs
+++ b/web/src/models/mod.rs
@@ -10,4 +10,4 @@ mod post;
 
 pub use error::*;
 pub use info::{InfoModel, Link};
-pub use post::{Href, PostModel};
+pub use post::PostModel;

--- a/web/src/models/post.rs
+++ b/web/src/models/post.rs
@@ -15,45 +15,7 @@ pub struct PostModel {
     pub description: String,
     pub cover: String,
     pub date: String,
-    pub content: Vec<Href>,
-}
-
-// The content token reference model.
-// Which is a dynamic structure that could represent:
-// - text(normal/linked)
-// - image
-// - code-snippet
-//
-// Each that representation should be handled by [Href]'s [type].
-// And [src] of [Href] is the main source of value.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-pub struct Href {
-    // typ is a field that represents the rendering style of [Href].
-    //
-    // Could be:
-    //  - text
-    //  - image
-    //  - code
-    pub typ: String,
-
-    // src is a field that used as source of content that has to be rendered.
-    pub src: String,
-
-    // Style is a font-style identifier of [src] field.
-    // > In case of [type] being any kind of text type.
-    //
-    // Could be:
-    //  - bold
-    //  - italic
-    //  - strong
-    pub style: String,
-
-    // The reference URL provider for [src].
-    // > In case of [type] being linked text type. <text>.
-    //
-    // same approach of `<a href="http://">{Src}</a>`
-    // but in rust structure model.
-    pub url: String,
+    pub content: String,
 }
 
 impl ToHtml for PostModel {
@@ -84,66 +46,5 @@ impl ToHtml for Vec<PostModel> {
         }
 
         return posts;
-    }
-}
-
-impl ToHtml for Href {
-    // Generates a valid [VNode] representation from [Href].
-    fn to_html(&self) -> Vec<VNode> {
-        let rendered = match self.clone().typ.clone().as_str() {
-            // TODO: add divider type match.
-            "image" => {
-                html! { <img class="post-full-image" src={ self.clone().src.clone() } alt="image" /> }
-            }
-            "code" => html! {
-                <div class="language-plaintext highlighter-rouge">
-                  <div class="highlight">
-                   <pre class="highlight">
-                    <code> { self.clone().src.clone().as_str() } </code>
-                   </pre>
-                  </div>
-                </div>
-            },
-            _ => {
-                let current = {
-                    if self.url.is_empty() {
-                        if self.clone().src.clone().as_str() == "\n"
-                            || self.clone().src.clone().as_str() == "\\n"
-                        {
-                            html! { <br/> }
-                        } else {
-                            html! { self.clone().src.clone() }
-                        }
-                    } else {
-                        html! {
-                            <a href={ self.clone().url.clone() }> { self.clone().src.clone() } </a>
-                        }
-                    }
-                };
-
-                match self.style.clone().as_str() {
-                    "bold" => html! {<b>{ current.clone() }</b>},
-                    "italic" => html! {<i>{ current.clone() }</i>},
-                    "strong" => html! {<strong>{ current.clone() }</strong>},
-                    "header" => html! {<h2> { current.clone() } </h2> },
-                    "p" => html! { <p> { current.clone() } </p> },
-                    _ => current.clone(),
-                }
-            }
-        };
-
-        return vec![rendered];
-    }
-}
-
-impl ToHtml for Vec<Href> {
-    // Generates a valid vector of [VNode] from vector of [Href]
-    fn to_html(&self) -> Vec<VNode> {
-        let mut hrefs: Vec<VNode> = Vec::new();
-        for h in self.clone().iter() {
-            hrefs.push(h.clone().to_html().iter().nth(0).unwrap().clone());
-        }
-
-        return hrefs;
     }
 }

--- a/web/src/routes/blog.rs
+++ b/web/src/routes/blog.rs
@@ -4,7 +4,7 @@
 // that can be found in the LICENSE file.
 //
 
-use crate::components::{ErrorCard, Loading, RainbowDivider};
+use crate::components::{ErrorCard, HtmlRender, Loading, RainbowDivider};
 use crate::models::{Error, PostModel};
 use crate::services::BlogService;
 use crate::utils::ToHtml;
@@ -112,12 +112,11 @@ pub fn blog_page(BlogPageProps { id }: &BlogPageProps) -> Html {
             None => html! { <Loading/> },
         },
         Some(v) => {
-            let content = VList::with_children(v.clone().content.clone().to_html().clone(), None);
             let children: Vec<VNode> = vec![
                 html! { <h1> { v.clone().title.clone() } </h1> },
                 html! { <p class="meta"> { v.clone().date.clone() } </p> },
                 html! { <RainbowDivider/> },
-                html! { content.clone() },
+                html! { <HtmlRender html={ v.clone().content.clone() }/>},
             ];
 
             let collected_vlist = VList::with_children(children, None);

--- a/web/src/routes/blog.rs
+++ b/web/src/routes/blog.rs
@@ -11,6 +11,9 @@ use crate::utils::ToHtml;
 
 use yew::prelude::*;
 use yew::virtual_dom::{VList, VNode};
+use yew_router::prelude::*;
+
+use super::Route;
 
 #[function_component(BlogList)]
 pub fn blog_list() -> Html {
@@ -47,12 +50,9 @@ pub fn blog_list() -> Html {
             let mut index = 0;
             let mut re_rendered: Vec<VNode> = Vec::new();
             for post in blogs.clone().iter() {
-                let route = format!(
-                    "/blog/{}",
-                    v.clone().iter().nth(index).unwrap().clone().id.clone()
-                );
+                let id = v.clone().iter().nth(index).unwrap().clone().id.clone();
 
-                re_rendered.push(html! { <a href={ route.clone() }> { post.clone() } </a> });
+                re_rendered.push(html! { <Link<Route> to={Route::BlogPage { id }}> { post.clone() } </Link<Route>> });
                 if index != blogs.len() - 1 {
                     re_rendered.push(html! { <RainbowDivider/> })
                 }

--- a/web/src/styles/main.css
+++ b/web/src/styles/main.css
@@ -296,7 +296,7 @@ blockquote {
   font-size: 14px;
   color: rgba(255, 165, 0, 0.5);
   text-align: right;
-  matgin-top: 2px;
+  margin-top: 2px;
 }
 
 .rainbow {
@@ -306,7 +306,7 @@ blockquote {
 }
 
 .post-full-image {
-  align: center;
+  box-align: center;
   height: 120px;
   border-radius: 6px;
   margin-bottom: 1em;
@@ -492,62 +492,313 @@ blockquote {
   }
 }
 
-.highlight .c { color: #999988; font-style: italic } /* Comment */
-.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
-.highlight .k { font-weight: bold } /* Keyword */
-.highlight .o { font-weight: bold } /* Operator */
-.highlight .cm { color: #999988; font-style: italic } /* Comment.Multiline */
-.highlight .cp { color: #999999; font-weight: bold } /* Comment.Preproc */
-.highlight .c1 { color: #999988; font-style: italic } /* Comment.Single */
-.highlight .cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
-.highlight .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
-.highlight .gd .x { color: #000000; background-color: #ffaaaa } /* Generic.Deleted.Specific */
-.highlight .ge { font-style: italic } /* Generic.Emph */
-.highlight .gr { color: #aa0000 } /* Generic.Error */
-.highlight .gh { color: #999999 } /* Generic.Heading */
-.highlight .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
-.highlight .gi .x { color: #000000; background-color: #aaffaa } /* Generic.Inserted.Specific */
-.highlight .go { color: #888888 } /* Generic.Output */
-.highlight .gp { color: #555555 } /* Generic.Prompt */
-.highlight .gs { font-weight: bold } /* Generic.Strong */
-.highlight .gu { color: #aaaaaa } /* Generic.Subheading */
-.highlight .gt { color: #aa0000 } /* Generic.Traceback */
-.highlight .kc { font-weight: bold } /* Keyword.Constant */
-.highlight .kd { font-weight: bold } /* Keyword.Declaration */
-.highlight .kp { font-weight: bold } /* Keyword.Pseudo */
-.highlight .kr { font-weight: bold } /* Keyword.Reserved */
-.highlight .kt { color: #445588; font-weight: bold } /* Keyword.Type */
-.highlight .m { color: #009999 } /* Literal.Number */
-.highlight .s { color: #d14 } /* Literal.String */
-.highlight .na { color: #008080 } /* Name.Attribute */
-.highlight .nb { color: #0086B3 } /* Name.Builtin */
-.highlight .nc { color: #445588; font-weight: bold } /* Name.Class */
-.highlight .no { color: #008080 } /* Name.Constant */
-.highlight .ni { color: #800080 } /* Name.Entity */
-.highlight .ne { color: #990000; font-weight: bold } /* Name.Exception */
-.highlight .nf { color: #990000; font-weight: bold } /* Name.Function */
-.highlight .nn { color: #555555 } /* Name.Namespace */
-.highlight .nt { color: #000080 } /* Name.Tag */
-.highlight .nv { color: #008080 } /* Name.Variable */
-.highlight .ow { font-weight: bold } /* Operator.Word */
-.highlight .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight .mf { color: #009999 } /* Literal.Number.Float */
-.highlight .mh { color: #009999 } /* Literal.Number.Hex */
-.highlight .mi { color: #009999 } /* Literal.Number.Integer */
-.highlight .mo { color: #009999 } /* Literal.Number.Oct */
-.highlight .sb { color: #d14 } /* Literal.String.Backtick */
-.highlight .sc { color: #d14 } /* Literal.String.Char */
-.highlight .sd { color: #d14 } /* Literal.String.Doc */
-.highlight .s2 { color: #d14 } /* Literal.String.Double */
-.highlight .se { color: #d14 } /* Literal.String.Escape */
-.highlight .sh { color: #d14 } /* Literal.String.Heredoc */
-.highlight .si { color: #d14 } /* Literal.String.Interpol */
-.highlight .sx { color: #d14 } /* Literal.String.Other */
-.highlight .sr { color: #009926 } /* Literal.String.Regex */
-.highlight .s1 { color: #d14 } /* Literal.String.Single */
-.highlight .ss { color: #990073 } /* Literal.String.Symbol */
-.highlight .bp { color: #999999 } /* Name.Builtin.Pseudo */
-.highlight .vc { color: #008080 } /* Name.Variable.Class */
-.highlight .vg { color: #008080 } /* Name.Variable.Global */
-.highlight .vi { color: #008080 } /* Name.Variable.Instance */
-.highlight .il { color: #009999 } /* Literal.Number.Integer.Long */
+.highlight .c {
+  color: #999988;
+  font-style: italic
+}
+
+/* Comment */
+.highlight .err {
+  color: #a61717;
+  background-color: #e3d2d2
+}
+
+/* Error */
+.highlight .k {
+  font-weight: bold
+}
+
+/* Keyword */
+.highlight .o {
+  font-weight: bold
+}
+
+/* Operator */
+.highlight .cm {
+  color: #999988;
+  font-style: italic
+}
+
+/* Comment.Multiline */
+.highlight .cp {
+  color: #999999;
+  font-weight: bold
+}
+
+/* Comment.Preproc */
+.highlight .c1 {
+  color: #999988;
+  font-style: italic
+}
+
+/* Comment.Single */
+.highlight .cs {
+  color: #999999;
+  font-weight: bold;
+  font-style: italic
+}
+
+/* Comment.Special */
+.highlight .gd {
+  color: #000000;
+  background-color: #ffdddd
+}
+
+/* Generic.Deleted */
+.highlight .gd .x {
+  color: #000000;
+  background-color: #ffaaaa
+}
+
+/* Generic.Deleted.Specific */
+.highlight .ge {
+  font-style: italic
+}
+
+/* Generic.Emph */
+.highlight .gr {
+  color: #aa0000
+}
+
+/* Generic.Error */
+.highlight .gh {
+  color: #999999
+}
+
+/* Generic.Heading */
+.highlight .gi {
+  color: #000000;
+  background-color: #ddffdd
+}
+
+/* Generic.Inserted */
+.highlight .gi .x {
+  color: #000000;
+  background-color: #aaffaa
+}
+
+/* Generic.Inserted.Specific */
+.highlight .go {
+  color: #888888
+}
+
+/* Generic.Output */
+.highlight .gp {
+  color: #555555
+}
+
+/* Generic.Prompt */
+.highlight .gs {
+  font-weight: bold
+}
+
+/* Generic.Strong */
+.highlight .gu {
+  color: #aaaaaa
+}
+
+/* Generic.Subheading */
+.highlight .gt {
+  color: #aa0000
+}
+
+/* Generic.Traceback */
+.highlight .kc {
+  font-weight: bold
+}
+
+/* Keyword.Constant */
+.highlight .kd {
+  font-weight: bold
+}
+
+/* Keyword.Declaration */
+.highlight .kp {
+  font-weight: bold
+}
+
+/* Keyword.Pseudo */
+.highlight .kr {
+  font-weight: bold
+}
+
+/* Keyword.Reserved */
+.highlight .kt {
+  color: #445588;
+  font-weight: bold
+}
+
+/* Keyword.Type */
+.highlight .m {
+  color: #009999
+}
+
+/* Literal.Number */
+.highlight .s {
+  color: #d14
+}
+
+/* Literal.String */
+.highlight .na {
+  color: #008080
+}
+
+/* Name.Attribute */
+.highlight .nb {
+  color: #0086B3
+}
+
+/* Name.Builtin */
+.highlight .nc {
+  color: #445588;
+  font-weight: bold
+}
+
+/* Name.Class */
+.highlight .no {
+  color: #008080
+}
+
+/* Name.Constant */
+.highlight .ni {
+  color: #800080
+}
+
+/* Name.Entity */
+.highlight .ne {
+  color: #990000;
+  font-weight: bold
+}
+
+/* Name.Exception */
+.highlight .nf {
+  color: #990000;
+  font-weight: bold
+}
+
+/* Name.Function */
+.highlight .nn {
+  color: #555555
+}
+
+/* Name.Namespace */
+.highlight .nt {
+  color: #000080
+}
+
+/* Name.Tag */
+.highlight .nv {
+  color: #008080
+}
+
+/* Name.Variable */
+.highlight .ow {
+  font-weight: bold
+}
+
+/* Operator.Word */
+.highlight .w {
+  color: #bbbbbb
+}
+
+/* Text.Whitespace */
+.highlight .mf {
+  color: #009999
+}
+
+/* Literal.Number.Float */
+.highlight .mh {
+  color: #009999
+}
+
+/* Literal.Number.Hex */
+.highlight .mi {
+  color: #009999
+}
+
+/* Literal.Number.Integer */
+.highlight .mo {
+  color: #009999
+}
+
+/* Literal.Number.Oct */
+.highlight .sb {
+  color: #d14
+}
+
+/* Literal.String.Backtick */
+.highlight .sc {
+  color: #d14
+}
+
+/* Literal.String.Char */
+.highlight .sd {
+  color: #d14
+}
+
+/* Literal.String.Doc */
+.highlight .s2 {
+  color: #d14
+}
+
+/* Literal.String.Double */
+.highlight .se {
+  color: #d14
+}
+
+/* Literal.String.Escape */
+.highlight .sh {
+  color: #d14
+}
+
+/* Literal.String.Heredoc */
+.highlight .si {
+  color: #d14
+}
+
+/* Literal.String.Interpol */
+.highlight .sx {
+  color: #d14
+}
+
+/* Literal.String.Other */
+.highlight .sr {
+  color: #009926
+}
+
+/* Literal.String.Regex */
+.highlight .s1 {
+  color: #d14
+}
+
+/* Literal.String.Single */
+.highlight .ss {
+  color: #990073
+}
+
+/* Literal.String.Symbol */
+.highlight .bp {
+  color: #999999
+}
+
+/* Name.Builtin.Pseudo */
+.highlight .vc {
+  color: #008080
+}
+
+/* Name.Variable.Class */
+.highlight .vg {
+  color: #008080
+}
+
+/* Name.Variable.Global */
+.highlight .vi {
+  color: #008080
+}
+
+/* Name.Variable.Instance */
+.highlight .il {
+  color: #009999
+}
+
+/* Literal.Number.Integer.Long */

--- a/web/src/styles/main.css
+++ b/web/src/styles/main.css
@@ -189,7 +189,7 @@ blockquote {
 }
 
 .footer {
-  margin-top: 3em;
+  margin-top: 5em;
   text-align: center;
   color: grey;
 }
@@ -287,13 +287,13 @@ blockquote {
 }
 
 .post-preview-desc {
-  font-size: 15px;
+  font-size: 14px;
   margin-bottom: 2px;
   color: rgba(0, 0, 0, 0.5);
 }
 
 .post-preview-date {
-  font-size: 15px;
+  font-size: 14px;
   color: rgba(255, 165, 0, 0.5);
   text-align: right;
   matgin-top: 2px;


### PR DESCRIPTION
Updates the Post model by converting the content field to string and removing [Href] model.
By that, now posts are pure html instead of custom JSON render objects.

### Commits:
- feat: remove href model and change component field's type to string
- feat: fix wrong modelling of different endpoints
- feat: convert post model's [content] field to String from Vec<Href>
- feat: add [HtmlRender] component to generate [VNode] from pure string
- feat: remove privacy-policy empty reference & update footer style
- feat: use Link of yew_router instead referencing directly URLs
- hotfix: fix the css typos
